### PR TITLE
Clean up remaining warning

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: r
+sudo: required
+r_binary_packages:
+  - shiny
+  - dplyr
+  - testthat
+warnings_are_errors: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
   person(family="Ajax.org B.V.", role=c("ctb", "cph"), comment="Ace"))
 Description: Ace editor bindings to enable a rich text editing environment
     within Shiny.
-License: MIT
+License: MIT + file LICENSE
 Depends:
     R (>= 2.15.0)
 Imports:
@@ -19,4 +19,3 @@ Suggests:
     testthat,
     dplyr (>= 0.3.0)
 BugReports: https://github.com/trestletech/shinyAce/issues
-License: MIT + file LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,2 @@
-YEAR: 2013
-
-COPYRIGHT HOLDER: Jeff Allen
+YEAR: 2016
+COPYRIGHT HOLDER: Jeff Allen, Ajax.org B.V. (Ace)

--- a/R/ace-autocomplete.R
+++ b/R/ace-autocomplete.R
@@ -22,8 +22,11 @@ aceAutocomplete <- function(inputId, session = shiny::getDefaultReactiveDomain()
     value <- session$input[[paste0("shinyAce_", inputId, "_hint")]]
     if(is.null(value)) return(NULL)
     
+    utilEnv <- environment(utils::alarm)
+    w32 <- get(".win32consoleCompletion", utilEnv)
+    
     comps <- list(id = inputId,
-                  codeCompletions = utils:::.win32consoleCompletion(value$linebuffer, value$cursorPosition)$comps)
+                  codeCompletions = w32(value$linebuffer, value$cursorPosition)$comps)
     
     session$sendCustomMessage('shinyAce', comps)
   })

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 shinyAce
 ==========
 
+[![Build Status](https://travis-ci.org/trestletech/shinyAce.svg?branch=master)](https://travis-ci.org/trestletech/shinyAce)
+
 The `shinyAce` package enables Shiny application developers to use the 
 [Ace text editor](http://ace.c9.io/#nav=about) in their applications. All
 current modes (languages) and themes are supported in this package. The 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributors (In order of first commit)
 ---------------------------------------
 
  - [Jeff Allen](https://github.com/trestletech) - Core project
- - [Vincent Nijs](https://github.com/mostly-harmless) - Vim key bindings ([#9](https://github.com/trestletech/shinyAce/pull/9))
+ - [Vincent Nijs](https://github.com/mostly-harmless) - Vim key bindings, package maintenance ([#9](https://github.com/trestletech/shinyAce/pull/9), [#35](https://github.com/trestletech/shinyAce/pull/35))
  - [Nick Carchedi](https://github.com/ncarchedi) - Word wrapping ([#12](https://github.com/trestletech/shinyAce/pull/12))
  - [Sebastian Kranz](https://github.com/skranz) - Hotkey feature and cursor listener ([#16](https://github.com/trestletech/shinyAce/pull/16/files))
  - [Forest Fang](https://github.com/saurfang) - Code completion ([#21](https://github.com/trestletech/shinyAce/pull/21))

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributors (In order of first commit)
 ---------------------------------------
 
  - [Jeff Allen](https://github.com/trestletech) - Core project
- - [Vincent Nijs](https://github.com/mostly-harmless) - Vim key bindings, package maintenance ([#9](https://github.com/trestletech/shinyAce/pull/9), [#35](https://github.com/trestletech/shinyAce/pull/35))
+ - [Vincent Nijs](https://github.com/vnijs) - Vim key bindings, package maintenance ([#9](https://github.com/trestletech/shinyAce/pull/9), [#35](https://github.com/trestletech/shinyAce/pull/35))
  - [Nick Carchedi](https://github.com/ncarchedi) - Word wrapping ([#12](https://github.com/trestletech/shinyAce/pull/12))
  - [Sebastian Kranz](https://github.com/skranz) - Hotkey feature and cursor listener ([#16](https://github.com/trestletech/shinyAce/pull/16/files))
  - [Forest Fang](https://github.com/saurfang) - Code completion ([#21](https://github.com/trestletech/shinyAce/pull/21))


### PR DESCRIPTION
When checking with `--as-cran` I still got a warning on the `:::` import. Thankfully that check doesn't trigger if I manually reach into the environment as I'm doing now :grimacing:. 

Sorry for the other noise -- it's me adding Travis build information for automated checking so I'm not caught off-guard by `R CMD CHECK`-breaking PRs in the future and hopefully can keep this package in a clean state moving forward.